### PR TITLE
Disable rustyline bracketed paste mode by default

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -670,6 +670,9 @@ fn default_rustyline_editor_configuration() -> Editor<Helper> {
         Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)),
     );
 
+    // workaround for multiline-paste hang in rustyline (see https://github.com/kkawakam/rustyline/issues/202)
+    rl.bind_sequence(KeyPress::BracketedPasteStart, rustyline::Cmd::Noop);
+    
     // Let's set the defaults up front and then override them later if the user indicates
     // defaults taken from here https://github.com/kkawakam/rustyline/blob/2fe886c9576c1ea13ca0e5808053ad491a6fe049/src/config.rs#L150-L167
     rl.set_max_history_size(100);


### PR DESCRIPTION
This should fix https://github.com/nushell/nushell/issues/2596.

Multiline pastes wait for the user to hit enter before running,
because they enter a special paste mode in rustyline called
'bracketed paste' by default. This commit disables that mode
by default for nushell, causing multiline pastes to be executed
immediately, treating each newline as a separate command.

### Examples:
Before this PR, pasting this
```
head -n 1 features.toml
head -n 1 features.toml

```
results in this:
```
/workspace/nushell(main)> head -n 1 features.toml
head -n 1 features.toml

|
```
(`|` inserted above to represent cursor) and waits for input. After hitting enter, the total exchange looks like this:
```
/workspace/nushell(main)> head -n 1 features.toml
head -n 1 features.toml


==> features.toml <==
[hintsv1]
head: cannot open 'head' for reading: No such file or directory

==> features.toml <==
[hintsv1]
/workspace/nushell(main)>
```
Having to hit enter is a little annoying, but from the `head: cannot...` error message, you can also see the result is incorrect -- each subsequent newline-demarcated command was treated as part of the first command.

After this PR, pasting this:
```
head -n 1 features.toml
head -n 1 features.toml

```
results in this:
```
/workspace/nushell(main)> head -n 1 features.toml
[hintsv1]
/workspace/nushell(main)> head -n 1 features.toml
[hintsv1]
/workspace/nushell(main)>
```
which matches expectations.

### Issues:
- I'm not sure how to add a test for this
- pasting multiple echos does not work as expected:
```
echo "test one"
echo "test two"

```
results in:
```
/workspace/nushell(main)> echo "test one"
/workspace/nushell(main)> echo "test two"
/workspace/nushell(main)> 
```
it seems the output gets overwritten. Investigating that, but it seems like it may be a different issue. It previously would result in the also-wrong:
```
/workspace/nushell(main)> echo "test one"
echo "test two"


───┬──────────
 0 │ test one 
 1 │ echo     
 2 │ test two 
───┴──────────
/workspace/nushell(main)> 
```
(after you hit enter post-paste).